### PR TITLE
Add examples

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,8 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    @import("set_version").VersionSetterStep.addStep(b);
+
     const dep_cobore_core = b.dependency("cbor_source", .{});
 
     const lib_core = b.addStaticLibrary(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -27,6 +27,10 @@
             .url = "git+https://github.com/libmcu/cbor#f3d1696f886b5f1d8f50cd5ed21521981e50ce15",
             .hash = "1220a3ae11bc664ab55ec406f99c9e23750da2e54d4f61dd0a5cf5ef247763e8a042",
         },
+        .set_version = .{
+            .url = "git+https://github.com/ritalin/zig-set-version#db61db987b1bd6ec4a4fe867999aea6c7b228fdf",
+            .hash = "1220ca307fab053314edf01c8e7c6d338e300f1162d793a4bbaf958e57bd5f509446",
+        },
     },
     .paths = .{
         "build.zig",

--- a/tests/02_libcbor/README.md
+++ b/tests/02_libcbor/README.md
@@ -1,0 +1,45 @@
+# libcbor
+
+## Requirement
+
+* Zig 0.14.0 or latter
+* libcbor (https://github.com/PJK/libcbor)
+
+## Test recipe
+
+Encode(libcbor) -> Decode(zig-cbor-stream)
+
+* u8, u16, u32, u64 (type 0)
+* i8, i16, i32, i64 (type 1)
+* utf8 string (type 3)
+* Tuple (type 4)
+* Array of unsigned integer
+* Array of signed integer
+* Array of utf8 string (type 4)
+* Array of tuple (type 4)
+* Bool value (type 7, short 20, 21)
+* Optional value (type 7, short 22)
+
+Encode(zig-cbor-stream) -> Decode(libcbor)
+
+* u8, u16, u32, u64 (type 0)
+* i8, i16, i32, i64 (type 1)
+* utf8 string (type 3)
+* Tuple (type 4)
+* Array of unsigned integer
+* Array of signed integer
+* Array of utf8 string (type 4)
+* Array of tuple (type 4)
+* Bool value (type 7, short 20, 21)
+* Optional value (type 7, short 22)
+
+
+Unsupported
+
+* Chunked string from (type 3, short 31)
+* Chunked string to (type 7, short 31)
+* Struct (type 5)
+* Array of struct (type 4)
+* f16, f32, f64 (type 7, short 25-27)
+* Semantic tag (type 6)
+

--- a/tests/02_libcbor/build.zig
+++ b/tests/02_libcbor/build.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+
+    
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
+}

--- a/tests/02_libcbor/build.zig.zon
+++ b/tests/02_libcbor/build.zig.zon
@@ -1,0 +1,72 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "02_from_libcbor",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.0.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{
+        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
+        //.example = .{
+        //    // When updating this field to a new URL, be sure to delete the corresponding
+        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
+        //    // the new URL.
+        //    .url = "https://example.com/foo.tar.gz",
+        //
+        //    // This is computed from the file contents of the directory of files that is
+        //    // obtained after fetching `url` and applying the inclusion rules given by
+        //    // `paths`.
+        //    //
+        //    // This field is the source of truth; packages do not come from a `url`; they
+        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
+        //    // obtain a package matching this `hash`.
+        //    //
+        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
+        //    .hash = "...",
+        //
+        //    // When this is provided, the package is found in a directory relative to the
+        //    // build root. In this case the package's hash is irrelevant and therefore not
+        //    // computed. This field and `url` are mutually exclusive.
+        //    .path = "foo",
+        //
+        //    // When this is set to `true`, a package is declared to be lazily
+        //    // fetched. This makes the dependency only get fetched if it is
+        //    // actually used.
+        //    .lazy = false,
+        //},
+    },
+
+    // Specifies the set of files and directories that are included in this package.
+    // Only files and directories listed here are included in the `hash` that
+    // is computed for this package. Only files listed here will remain on disk
+    // when using the zig package manager. As a rule of thumb, one should list
+    // files required for compilation plus any license(s).
+    // Paths are relative to the build root. Use the empty string (`""`) to refer to
+    // the build root itself.
+    // A directory listed here means that all files within, recursively, are included.
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/tests/02_libcbor/src/root.zig
+++ b/tests/02_libcbor/src/root.zig
@@ -1,0 +1,2 @@
+const std = @import("std");
+


### PR DESCRIPTION
This PR is adding examples between some `cbor` implementations.

* [ ] zbor (https://github.com/r4gus/zbor) ⭐️36
* [ ]  libCbor (https://github.com/PJK/libcbor) ⭐️342
* [ ] tinyCBor (https://github.com/intel/tinycbor) ⭐️503
* [ ] cbor-lite (https://bitbucket.org/isode/cbor-lite)
* [ ] cb0r (https://github.com/quartzjer/cb0r) ⭐️56
* [ ] QCBOR (https://github.com/laurencelundblade/QCBOR) ⭐️189